### PR TITLE
Improve straight flush evaluation

### DIFF
--- a/src/main/java/BluffOrBluff/model/HandEvaluator.java
+++ b/src/main/java/BluffOrBluff/model/HandEvaluator.java
@@ -34,6 +34,7 @@ public class HandEvaluator {
         return hand.stream()
                 .map(c -> c.getRank().ordinal())
                 .sorted(Comparator.reverseOrder())
+                .limit(5)
                 .toList();
     }
 
@@ -122,13 +123,47 @@ public class HandEvaluator {
         return false;
     }
 
+    private static List<List<Card>> getFiveCardCombos(List<Card> hand) {
+        List<List<Card>> combos = new ArrayList<>();
+        int n = hand.size();
+        if (n < 5) {
+            combos.add(new ArrayList<>(hand));
+            return combos;
+        }
+        for (int i = 0; i < n - 4; i++) {
+            for (int j = i + 1; j < n - 3; j++) {
+                for (int k = j + 1; k < n - 2; k++) {
+                    for (int l = k + 1; l < n - 1; l++) {
+                        for (int m = l + 1; m < n; m++) {
+                            combos.add(List.of(
+                                    hand.get(i), hand.get(j), hand.get(k),
+                                    hand.get(l), hand.get(m)));
+                        }
+                    }
+                }
+            }
+        }
+        return combos;
+    }
+
     private static boolean isStraightFlush(List<Card> hand) {
-        return isFlush(hand) && isStraight(hand);
+        for (List<Card> combo : getFiveCardCombos(hand)) {
+            if (isFlush(combo) && isStraight(combo)) {
+                return true;
+            }
+        }
+        return false;
     }
 
     private static boolean isRoyalFlush(List<Card> hand) {
         List<Card.Rank> royalRanks = List.of(Card.Rank.TEN, Card.Rank.JACK, Card.Rank.QUEEN, Card.Rank.KING, Card.Rank.ACE);
-        return isStraightFlush(hand) && hand.stream().allMatch(card -> royalRanks.contains(card.getRank()));
+        for (List<Card> combo : getFiveCardCombos(hand)) {
+            if (combo.stream().allMatch(card -> royalRanks.contains(card.getRank()))
+                    && isFlush(combo) && isStraight(combo)) {
+                return true;
+            }
+        }
+        return false;
     }
 
     public static int getPreFlopHandStrength(List<Card> holeCards) {

--- a/src/main/java/BluffOrBluff/test/HandEvaluatorTest.java
+++ b/src/main/java/BluffOrBluff/test/HandEvaluatorTest.java
@@ -23,6 +23,21 @@ public class HandEvaluatorTest {
     }
 
     @Test
+    public void testRoyalFlushFromSevenCards() {
+        List<Card> hand = List.of(
+                new Card(Card.Rank.TEN, Card.Suit.SPADES),
+                new Card(Card.Rank.JACK, Card.Suit.SPADES),
+                new Card(Card.Rank.QUEEN, Card.Suit.SPADES),
+                new Card(Card.Rank.KING, Card.Suit.SPADES),
+                new Card(Card.Rank.ACE, Card.Suit.SPADES),
+                new Card(Card.Rank.TWO, Card.Suit.CLUBS),
+                new Card(Card.Rank.THREE, Card.Suit.DIAMONDS)
+        );
+        HandRank result = HandEvaluator.evaluateHand(hand);
+        assertEquals("Royal Flush", result.getRank());
+    }
+
+    @Test
     public void testStraightFlush() {
         List<Card> straightFlush = List.of(
                 new Card(Card.Rank.SIX, Card.Suit.CLUBS),
@@ -32,6 +47,21 @@ public class HandEvaluatorTest {
                 new Card(Card.Rank.TEN, Card.Suit.CLUBS)
         );
         HandRank result = HandEvaluator.evaluateHand(straightFlush);
+        assertEquals("Straight Flush", result.getRank());
+    }
+
+    @Test
+    public void testStraightFlushFromSevenCards() {
+        List<Card> hand = List.of(
+                new Card(Card.Rank.TWO, Card.Suit.HEARTS),
+                new Card(Card.Rank.THREE, Card.Suit.HEARTS),
+                new Card(Card.Rank.FOUR, Card.Suit.HEARTS),
+                new Card(Card.Rank.FIVE, Card.Suit.HEARTS),
+                new Card(Card.Rank.SIX, Card.Suit.HEARTS),
+                new Card(Card.Rank.KING, Card.Suit.CLUBS),
+                new Card(Card.Rank.NINE, Card.Suit.DIAMONDS)
+        );
+        HandRank result = HandEvaluator.evaluateHand(hand);
         assertEquals("Straight Flush", result.getRank());
     }
 


### PR DESCRIPTION
## Summary
- ensure high cards only consider best 5 cards
- evaluate straight flush and royal flush across all 5‑card combos
- add regression tests for 7‑card straight flush and royal flush cases

## Testing
- `javac --release 21 --enable-preview -classpath junit-platform-console-standalone.jar @sources.txt`
- `java --enable-preview -jar junit-platform-console-standalone.jar --class-path src/main/java -cp src/main/java -classpath src/main/java -scan-class-path`

------